### PR TITLE
Add clap-to-jump dino game to /fun/ page

### DIFF
--- a/fun.md
+++ b/fun.md
@@ -40,3 +40,17 @@ some browser toys, mostly audio/visual. they use your microphone or camera and n
   </div>
 
 </div>
+
+<div class="content-narrow content-block">
+
+  <h3>clap jump</h3>
+  <p>clap to jump. dodge the cacti. spacebar also works if you don't have a mic.</p>
+
+  <div class="toy-widget">
+    <canvas id="dino-canvas" width="600" height="150"></canvas>
+    <br>
+    <button id="dino-btn">Start game</button>
+    <p class="note">requires microphone &mdash; clap detection runs locally, nothing is sent anywhere.</p>
+  </div>
+
+</div>

--- a/styling/main.scss
+++ b/styling/main.scss
@@ -276,6 +276,10 @@ a {
   }
 }
 
+#dino-canvas {
+  background: $background-color;
+}
+
 /**
  * lightbox
  */

--- a/styling/toys.js
+++ b/styling/toys.js
@@ -87,6 +87,277 @@ function scrollLeft(canvas, ctx) {
   });
 })();
 
+// ─── CLAP JUMP (dino game) ────────────────────────────────────────────────────
+(function () {
+  const canvas = document.getElementById('dino-canvas');
+  if (!canvas) return;
+  const ctx = canvas.getContext('2d');
+  const btn = document.getElementById('dino-btn');
+
+  const W = canvas.width;
+  const H = canvas.height;
+  const GROUND_Y = H - 20;
+  const COL_DARK  = '#043927';
+  const COL_MID   = '#728c69';
+  const COL_BG    = '#f5f5f5';
+
+  // --- character ---
+  const CHAR_X = 60;
+  const CHAR_W = 16;
+  const CHAR_H = 26;
+  let charY = GROUND_Y - CHAR_H;
+  let velY = 0;
+  let onGround = true;
+  let legFrame = 0;
+
+  // --- obstacles ---
+  let cacti = [];
+  let speed = 4;
+  let spawnInterval = 1400;
+  let lastSpawn = 0;
+
+  // --- scoring ---
+  let score = 0;
+  let best = 0;
+  let frameCount = 0;
+
+  // --- state ---
+  let state = 'idle'; // idle | running | dead
+  let animId = null;
+  let stream = null;
+  let audioCtx = null;
+
+  // --- clap detection ---
+  let analyser = null;
+  let clapData = null;
+  let bgEnergy = 0.001;
+  let lastClap = 0;
+
+  function detectClap() {
+    if (!analyser) return false;
+    analyser.getByteTimeDomainData(clapData);
+    let rms = 0;
+    for (let i = 0; i < clapData.length; i++) {
+      const s = (clapData[i] - 128) / 128;
+      rms += s * s;
+    }
+    rms = Math.sqrt(rms / clapData.length);
+    bgEnergy = bgEnergy * 0.95 + rms * 0.05;
+    const now = performance.now();
+    if (rms > bgEnergy * 2.8 && now - lastClap > 350) {
+      lastClap = now;
+      return true;
+    }
+    return false;
+  }
+
+  function jump() {
+    if (onGround) {
+      velY = -11;
+      onGround = false;
+    }
+  }
+
+  function spawnCactus(now) {
+    if (now - lastSpawn < spawnInterval) return;
+    lastSpawn = now;
+    const h = 32 + Math.random() * 24;
+    const hasArm = Math.random() > 0.4;
+    cacti.push({ x: W + 10, w: 14, h, hasArm });
+    // gradually speed up
+    speed = 4 + Math.min(score / 800, 4);
+    spawnInterval = Math.max(800, 1400 - score / 4);
+  }
+
+  function drawCharacter() {
+    ctx.fillStyle = COL_DARK;
+    // body
+    ctx.fillRect(CHAR_X, charY + 10, CHAR_W, 16);
+    // head
+    ctx.fillRect(CHAR_X + 2, charY, CHAR_W - 2, 12);
+    // eye
+    ctx.fillStyle = COL_BG;
+    ctx.fillRect(CHAR_X + CHAR_W - 5, charY + 2, 3, 3);
+    ctx.fillStyle = COL_DARK;
+    // legs (alternate when running, static when jumping)
+    if (onGround) {
+      const l = Math.floor(legFrame / 8) % 2;
+      ctx.fillRect(CHAR_X + 2,      charY + 26, 5, l === 0 ? 6 : 4);
+      ctx.fillRect(CHAR_X + CHAR_W - 7, charY + 26, 5, l === 0 ? 4 : 6);
+    } else {
+      ctx.fillRect(CHAR_X + 2,      charY + 26, 5, 5);
+      ctx.fillRect(CHAR_X + CHAR_W - 7, charY + 26, 5, 5);
+    }
+  }
+
+  function drawCactus(c) {
+    ctx.fillStyle = COL_MID;
+    const baseY = GROUND_Y - c.h;
+    ctx.fillRect(c.x, baseY, c.w, c.h);
+    if (c.hasArm) {
+      // left arm
+      ctx.fillRect(c.x - 8, baseY + 8, 8, 7);
+      ctx.fillRect(c.x - 8, baseY + 2, 5, 8);
+    }
+  }
+
+  function collides(c) {
+    const cx = c.x + 2, cw = c.w - 4;
+    const cy = GROUND_Y - c.h, ch = c.h;
+    return (
+      CHAR_X + 3 < cx + cw &&
+      CHAR_X + CHAR_W - 3 > cx &&
+      charY + 6 < cy + ch &&
+      charY + CHAR_H > cy
+    );
+  }
+
+  function drawScene(now) {
+    // background
+    ctx.fillStyle = COL_BG;
+    ctx.fillRect(0, 0, W, H);
+
+    // ground
+    ctx.fillStyle = COL_DARK;
+    ctx.fillRect(0, GROUND_Y, W, 2);
+
+    // cacti
+    for (const c of cacti) drawCactus(c);
+
+    // character
+    drawCharacter();
+
+    // score
+    ctx.fillStyle = COL_DARK;
+    ctx.font = '13px monospace';
+    ctx.textAlign = 'right';
+    ctx.fillText(`${Math.floor(score / 10)}`, W - 10, 18);
+    if (best > 0) ctx.fillText(`best ${Math.floor(best / 10)}`, W - 10, 34);
+    ctx.textAlign = 'left';
+  }
+
+  function drawIdle() {
+    ctx.fillStyle = COL_BG;
+    ctx.fillRect(0, 0, W, H);
+    ctx.fillStyle = COL_DARK;
+    ctx.fillRect(0, GROUND_Y, W, 2);
+    charY = GROUND_Y - CHAR_H;
+    drawCharacter();
+    ctx.fillStyle = COL_DARK;
+    ctx.font = '13px monospace';
+    ctx.textAlign = 'center';
+    ctx.fillText('click "Start game" to begin', W / 2, H / 2 - 10);
+    ctx.textAlign = 'left';
+  }
+
+  function drawDead() {
+    ctx.fillStyle = 'rgba(245,245,245,0.7)';
+    ctx.fillRect(0, 0, W, H);
+    ctx.fillStyle = COL_DARK;
+    ctx.font = 'bold 15px monospace';
+    ctx.textAlign = 'center';
+    ctx.fillText('game over', W / 2, H / 2 - 14);
+    ctx.font = '12px monospace';
+    ctx.fillText(`score: ${Math.floor(score / 10)}`, W / 2, H / 2 + 4);
+    ctx.fillText('clap or press space to restart', W / 2, H / 2 + 22);
+    ctx.textAlign = 'left';
+  }
+
+  function resetGame() {
+    charY = GROUND_Y - CHAR_H;
+    velY = 0;
+    onGround = true;
+    cacti = [];
+    speed = 4;
+    spawnInterval = 1400;
+    lastSpawn = 0;
+    score = 0;
+    frameCount = 0;
+    legFrame = 0;
+    state = 'running';
+  }
+
+  function loop(now) {
+    animId = requestAnimationFrame(loop);
+    const clapped = detectClap();
+
+    if (state === 'running') {
+      frameCount++;
+      score++;
+      legFrame++;
+
+      if (clapped) jump();
+
+      // physics
+      velY += 0.6;
+      charY += velY;
+      if (charY >= GROUND_Y - CHAR_H) {
+        charY = GROUND_Y - CHAR_H;
+        velY = 0;
+        onGround = true;
+      }
+
+      // spawn & move obstacles
+      spawnCactus(now);
+      for (const c of cacti) c.x -= speed;
+      cacti = cacti.filter(c => c.x + c.w + 20 > 0);
+
+      // collision
+      if (cacti.some(collides)) {
+        state = 'dead';
+        if (score > best) best = score;
+      }
+
+      drawScene(now);
+    } else if (state === 'dead') {
+      drawScene(now);
+      drawDead();
+      if (clapped) resetGame();
+    }
+  }
+
+  // keyboard fallback
+  document.addEventListener('keydown', (e) => {
+    if (e.code === 'Space') {
+      e.preventDefault();
+      if (state === 'running') jump();
+      else if (state === 'dead') resetGame();
+    }
+  });
+
+  btn.addEventListener('click', async () => {
+    if (animId) {
+      cancelAnimationFrame(animId);
+      animId = null;
+      if (stream) stream.getTracks().forEach(t => t.stop());
+      if (audioCtx) { audioCtx.close(); audioCtx = null; }
+      state = 'idle';
+      btn.textContent = 'Start game';
+      drawIdle();
+      return;
+    }
+
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
+      audioCtx = new (window.AudioContext || window.webkitAudioContext)();
+      const source = audioCtx.createMediaStreamSource(stream);
+      analyser = audioCtx.createAnalyser();
+      analyser.fftSize = 256;
+      source.connect(analyser);
+      clapData = new Uint8Array(analyser.fftSize);
+    } catch (e) {
+      // mic denied — game still works with spacebar
+      analyser = null;
+    }
+
+    resetGame();
+    btn.textContent = 'Stop game';
+    requestAnimationFrame(loop);
+  });
+
+  drawIdle();
+})();
+
 // ─── CAMERA PSEUDO-SPECTROGRAM ────────────────────────────────────────────────
 (function () {
   const canvas = document.getElementById('camera-canvas');


### PR DESCRIPTION
- fun.md: new "clap jump" section with 600×150 canvas + start/stop button
- styling/toys.js: canvas-based runner game driven by mic clap detection
  - Web Audio API AnalyserNode with RMS transient detection (cooldown 350ms)
  - Physics: gravity 0.6px/frame², jump velocity -11, ground collision
  - Cacti with optional arm shapes, speed and spawn-rate increase with score
  - States: idle → running → dead, restart on clap or spacebar
  - Graceful fallback: game runs on spacebar if mic permission is denied
- styling/main.scss: override #dino-canvas background to site bg color

https://claude.ai/code/session_01NtYfkPgLThm4dTv9sLUmFd