### PR TITLE
redesign research page and embed sax playlist on /music/

### DIFF
--- a/_includes/pub_entry.html
+++ b/_includes/pub_entry.html
@@ -1,46 +1,44 @@
-<div class="content-block">
+{%- assign pub = include.pub -%}
 
-  {{ include.pub.authors }}
-  {% if include.pub.in-prep %}
-  (in prep).
-  {% else %}
-  ({{ include.pub.date | date: "%Y" }}
-  {%- if include.pub.in-press -%}, in press {%- endif -%}).
-  {% endif %}
+<div class="pub-entry">
 
-  {% if include.pub.doi %} <a href="{{ include.pub.doi }}" target="_blank"> {% endif %}
-  {{ include.pub.title }}
-  {%- if include.pub.doi -%} </a> {%- endif -%}.
-
-  {% if include.pub.editor %}
-  In {{ include.pub.editor }} (Ed.),
-  {% endif %}
-
-  {%- if include.pub.journal -%}
-  <i> {{ include.pub.journal }}</i>
-  {%- if include.pub.volume -%}, {{ include.pub.volume }}
-  {%- if include.pub.issue -%}({{ include.pub.issue }}){%- endif -%}
-  {%- endif -%}.
+  {%- if pub.doi -%}
+    <a class="pub-title" href="{{ pub.doi }}" target="_blank">{{ pub.title }}</a>
+  {%- else -%}
+    <span class="pub-title">{{ pub.title }}</span>
   {%- endif -%}
 
-  {% if include.pub.publisher %}
-  {{ include.pub.publisher }}.
-  {% endif %}
+  <div class="pub-authors">{{ pub.authors }}</div>
 
-  {% if include.pub.ref-1-name %} [<a href="{{ include.pub.ref-1-link }}" target="_blank">{{ include.pub.ref-1-name }}</a>
-    {%- if include.pub.ref-2-name -%}, <a href="{{ include.pub.ref-2-link }}" target="_blank">{{ include.pub.ref-2-name }}</a>
-      {%- if include.pub.ref-3-name -%}, <a href="{{ include.pub.ref-3-link }}" target="_blank">{{ include.pub.ref-3-name }}</a>
-        {%- if include.pub.ref-4-name -%}, <a href="{{ include.pub.ref-4-link }}" target="_blank">{{ include.pub.ref-4-name }}</a>]
-        {%- else -%}]
-        {%- endif -%}
-      {%- else -%}]
+  <div class="pub-meta">
+    {%- if pub.in-prep -%}
+      in prep
+    {%- elsif pub.in-press -%}
+      {{ pub.journal }}, in press
+    {%- else -%}
+      {%- if pub.editor %}In {{ pub.editor }} (Ed.), {% endif -%}
+      {%- if pub.journal -%}
+        <i>{{ pub.journal }}</i>
+        {%- if pub.volume -%}, {{ pub.volume }}{%- if pub.issue %}({{ pub.issue }}){%- endif -%}{%- endif -%}
+        {%- if pub.publisher %} · {{ pub.publisher }}{%- endif -%}
+        ·
       {%- endif -%}
-    {%- else -%}]
+      {{ pub.date | date: "%Y" }}
     {%- endif -%}
-  {% endif %}
-
-  <div class="content-note">
-    {{ include.pub.content }}
   </div>
+
+  {%- if pub.ref-1-name or pub.ref-2-name or pub.ref-3-name or pub.ref-4-name -%}
+  <div class="pub-refs">
+    {%- if pub.ref-1-name %}<a href="{{ pub.ref-1-link }}" target="_blank">{{ pub.ref-1-name }}</a>{% endif -%}
+    {%- if pub.ref-2-name %}<a href="{{ pub.ref-2-link }}" target="_blank">{{ pub.ref-2-name }}</a>{% endif -%}
+    {%- if pub.ref-3-name %}<a href="{{ pub.ref-3-link }}" target="_blank">{{ pub.ref-3-name }}</a>{% endif -%}
+    {%- if pub.ref-4-name %}<a href="{{ pub.ref-4-link }}" target="_blank">{{ pub.ref-4-name }}</a>{% endif -%}
+  </div>
+  {%- endif -%}
+
+  {%- assign note = pub.content | strip -%}
+  {%- if note != "" -%}
+  <div class="pub-note">{{ note }}</div>
+  {%- endif -%}
 
 </div>

--- a/_publications/aversion.md
+++ b/_publications/aversion.md
@@ -1,10 +1,7 @@
-Aversion to screechy sounds varies with exposure to industrialized environments.
-
 ---
-title: Preferences for consonance are evident in Indigenous Amazonians with higher, but not lower, levels of global integration
-authors: McPherson-McNato M.J., Undurraga E.A., Poblete M., Rojas S., Zariquiey R., Seidle A., Medina,
-B.J., McDermott J.H.
+title: Aversion to screechy sounds varies with exposure to industrialized environments
+authors: McPherson-McNato M.J., Undurraga E.A., Poblete M., Rojas S., Zariquiey R., Seidle A., Medina B.J., McDermott J.H.
 paper: 4
 date: 2026-02-02
-journal: (IN REVIEW)
+journal: in review
 ---

--- a/music.md
+++ b/music.md
@@ -8,52 +8,32 @@ permalink: /music/
 
 ## saxophone
 
-a small collection of performances. mostly alto. some bass too. fill is rotating.
+a rotating collection of performances. mostly alto. some bass too.
 
 </div>
 
 <div class="content-narrow content-block">
 
-  <h3>performances</h3>
-
-  <!--
-    add a new performance by copying one of the blocks below.
-    - youtube: replace VIDEO_ID with the part after "v=" in the url
-    - local file: drop the file into /images/music/ (or wherever) and update src
-    delete the unused block.
-  -->
+  <h3>playlist</h3>
 
   <div class="performance">
     <div class="performance-media">
       <iframe
-        src="https://www.youtube.com/embed/VIDEO_ID"
-        title="YouTube performance"
+        src="https://www.youtube.com/embed/aIAzo2somjs?list=PL900nRJsGdducFcZvvCKv8HNbMuf1IRlb"
+        title="saxophone performances"
         frameborder="0"
         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
         allowfullscreen></iframe>
     </div>
-    <p class="performance-caption">title of the piece &mdash; venue, date</p>
-  </div>
-
-  <div class="performance">
-    <div class="performance-media">
-      <video controls preload="metadata">
-        <source src="/images/music/example.mp4" type="video/mp4">
-        your browser doesn't support embedded video.
-      </video>
-    </div>
-    <p class="performance-caption">title of the piece &mdash; venue, date</p>
-  </div>
-
-  <div class="performance">
-    <audio controls preload="metadata">
-      <source src="/images/music/example.mp3" type="audio/mpeg">
-      your browser doesn't support embedded audio.
-    </audio>
-    <p class="performance-caption">title of the piece &mdash; recording date</p>
+    <p class="performance-caption">full playlist on <a href="https://www.youtube.com/playlist?list=PL900nRJsGdducFcZvvCKv8HNbMuf1IRlb" target="_blank">youtube</a></p>
   </div>
 
 </div>
+
+<!--
+  want to feature individual videos or local recordings? add a new section
+  below by copying one of the blocks. drop local files into /images/music/.
+-->
 
 <div class="content-narrow content-block" markdown="1">
 

--- a/research.md
+++ b/research.md
@@ -1,20 +1,25 @@
 ---
 layout: default
-title: Research
+title: research
 permalink: /research/
 ---
-{:.content-list-header .content-block}
-**Papers**
 
 {% assign sorted = site.publications | sort: "date" | reverse %}
 
-{%- for pub in sorted -%}
-  {% if pub.paper %}{% include pub_entry.html pub=pub %}{%- endif -%}
-{% endfor %}
+<div class="content-narrow content-block">
+  <h2 class="pub-section-header">papers</h2>
+  <div class="pub-list">
+    {%- for pub in sorted -%}
+      {%- if pub.paper -%}{% include pub_entry.html pub=pub %}{%- endif -%}
+    {%- endfor -%}
+  </div>
+</div>
 
-{:.content-list-header .content-block}
-**Presentations**
-
-{%- for pub in sorted -%}
-  {% if pub.presentation %}{% include pub_entry.html pub=pub %}{%- endif -%}
-{% endfor %}
+<div class="content-narrow content-block">
+  <h2 class="pub-section-header">presentations</h2>
+  <div class="pub-list">
+    {%- for pub in sorted -%}
+      {%- if pub.presentation -%}{% include pub_entry.html pub=pub %}{%- endif -%}
+    {%- endfor -%}
+  </div>
+</div>

--- a/styling/main.scss
+++ b/styling/main.scss
@@ -294,6 +294,80 @@ a {
 }
 
 /**
+ * research / publications
+ */
+.pub-section-header {
+  font-size: $header-font-size;
+  font-weight: $emph-font-weight;
+  margin: 0 0 $unit-spacing;
+  padding-bottom: 0.3rem;
+  border-bottom: 1px solid $grey-color;
+}
+
+.pub-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.pub-entry {
+  line-height: 1.5;
+
+  .pub-title {
+    display: block;
+    font-weight: $emph-font-weight;
+    color: $brand-color-light;
+    margin-bottom: 0.15rem;
+  }
+
+  a.pub-title:hover {
+    color: $brand-color-dark;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  .pub-authors {
+    font-size: 0.95rem;
+    color: $text-color;
+  }
+
+  .pub-meta {
+    font-size: 0.9rem;
+    color: lighten($text-color, 20%);
+    margin-top: 0.1rem;
+  }
+
+  .pub-refs {
+    margin-top: 0.35rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+
+    a {
+      font-size: 0.8rem;
+      font-weight: $emph-font-weight;
+      padding: 0.15rem 0.55rem;
+      border: 1px solid $brand-color-dark;
+      color: $brand-color-dark;
+      border-radius: 3px;
+      transition: background 0.15s ease, color 0.15s ease;
+
+      &:hover {
+        background: $brand-color-dark;
+        color: #fff;
+        text-decoration: none;
+      }
+    }
+  }
+
+  .pub-note {
+    font-size: 0.88rem;
+    color: lighten($text-color, 15%);
+    margin-top: 0.35rem;
+  }
+}
+
+/**
  * performances (music page)
  */
 .performance {


### PR DESCRIPTION
- rewrite pub_entry.html: titled-link block, author/meta rows, pill-style ref links instead of bare "[PDF]" brackets; skip empty notes
- wrap papers/presentations in .content-narrow with section headers, separator line, and consistent spacing between entries
- restore valid front matter on aversion.md (text was above the ---, so jekyll treated it as plain content)
- replace music page placeholders with the youtube playlist embed