### PR TITLE
Add By George clip (Jazz Advanced Ensemble, Killian Hall, April 2026)

### DIFF
--- a/_data/sax_clips.yml
+++ b/_data/sax_clips.yml
@@ -67,5 +67,6 @@
   clips:
     - video: 0gIlvcx1bQY
       start: 2920
+      end: 3010
       title: By George (Coleman Gliddon) — solo
       note: written by another member of the ensemble

--- a/_data/sax_clips.yml
+++ b/_data/sax_clips.yml
@@ -60,3 +60,12 @@
       start: 1010
       end: 1185
       title: A Love Supreme (John Coltrane) — solo
+
+- venue: Killian Hall, MIT
+  date: 2026-04-30
+  meta: with the Jazz Advanced Music Performance Ensemble at MIT, led by Miguel Zenón
+  clips:
+    - video: 0gIlvcx1bQY
+      start: 0
+      title: By George (Coleman Gliddon) — solo
+      note: written by another member of the ensemble

--- a/_data/sax_clips.yml
+++ b/_data/sax_clips.yml
@@ -66,6 +66,6 @@
   meta: with the Jazz Advanced Music Performance Ensemble at MIT, led by Miguel Zenón
   clips:
     - video: 0gIlvcx1bQY
-      start: 0
+      start: 2920
       title: By George (Coleman Gliddon) — solo
       note: written by another member of the ensemble


### PR DESCRIPTION
Adds one more gig to `_data/sax_clips.yml`:

**Killian Hall, MIT — April 2026**
*with the Jazz Advanced Music Performance Ensemble at MIT, led by Miguel Zenón*

- *By George* (Coleman Gliddon) — solo, clipped to 48:40–50:10. Note: written by another member of the ensemble.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G49vu8bvUe1ZKN1AUh1Bff)_