### PR TITLE
Add Tull Concert Hall gig to /music/

### DIFF
--- a/_data/sax_clips.yml
+++ b/_data/sax_clips.yml
@@ -73,6 +73,7 @@
 
 - venue: Tull Concert Hall
   date: 2026-04-15
+  meta: with the Jazz Advanced Music Performance Ensemble at MIT, led by Miguel Zenón
   clips:
     - video: twp4FXo06G0
       start: 572

--- a/_data/sax_clips.yml
+++ b/_data/sax_clips.yml
@@ -63,7 +63,7 @@
 
 - venue: Killian Hall, MIT
   date: 2026-04-30
-  meta: with the Jazz Advanced Music Performance Ensemble at MIT, led by Miguel Zenón
+  meta: with MIT Jazz AMP (Advanced Music Performance), led by Miguel Zenón
   clips:
     - video: 0gIlvcx1bQY
       start: 2920
@@ -73,7 +73,7 @@
 
 - venue: Tull Concert Hall
   date: 2026-04-15
-  meta: with the Jazz Advanced Music Performance Ensemble at MIT, led by Miguel Zenón
+  meta: with MIT Jazz AMP (Advanced Music Performance), led by Miguel Zenón
   clips:
     - video: twp4FXo06G0
       start: 572

--- a/_data/sax_clips.yml
+++ b/_data/sax_clips.yml
@@ -70,3 +70,16 @@
       end: 3010
       title: By George (Coleman Gliddon) — solo
       note: written by another member of the ensemble
+
+- venue: Tull Concert Hall
+  date: 2026-04-15
+  clips:
+    - video: twp4FXo06G0
+      start: 572
+      end: 694
+      title: Coffee and Water (Alexander "Sasha" Mazurenko) — solo
+    - video: twp4FXo06G0
+      start: 2281
+      end: 2354
+      title: Untitled (Sabrina Drammis) — solo
+


### PR DESCRIPTION
Adds the Tull Concert Hall gig to `_data/sax_clips.yml`:

**Tull Concert Hall — April 2026**
*with MIT Jazz AMP (Advanced Music Performance), led by Miguel Zenón*

- Coffee and Water (Alexander "Sasha" Mazurenko) — solo · 9:32–11:34
- Untitled (Sabrina Drammis) — solo · 38:01–39:14

Also updates the late-April Killian gig's lineup line to the same abbreviated "MIT Jazz AMP" wording.

---
_Generated by [Claude Code](https://claude.ai/code/session_01G49vu8bvUe1ZKN1AUh1Bff)_